### PR TITLE
remove extra line, white spaces and add double quotes

### DIFF
--- a/lib/prj/prj_gen_mk.ml
+++ b/lib/prj/prj_gen_mk.ml
@@ -41,8 +41,7 @@ BUILD := ocamlbuild -j $(PARALLEL_JOBS) -build-dir $(BUILD_DIR) $(BUILD_FLAGS)
 MOD_DEPS=$(foreach DEP,$(DEPS), --depends $(DEP))
 BUILD_MOD_DEPS=$(foreach DEP,$(BUILD_DEPS), --build-depends $(DEP))
 
-UTOP_MODS=$(foreach DEP,$(DEPS), \\#require \"$(DEP)\";; ) \
-    $(foreach DEP,$(DEPS), \\#require \"$(DEP)\";; )
+UTOP_MODS=$(foreach DEP,$(DEPS),\\#require \\\"$(DEP)\\\";;)
 
 UTOP_INIT=$(BUILD_DIR)/init.ml
 


### PR DESCRIPTION
Without this `make utop` doesn't work (at least in linux and for sentinel)
